### PR TITLE
BUGFIX: null key used as set should throw

### DIFF
--- a/addon/weak-map.js
+++ b/addon/weak-map.js
@@ -14,20 +14,6 @@ function symbol() {
   return `__ember${dateKey}${id++}`;
 }
 
-function isPrimitiveType(thing) {
-  switch(typeof thing) {
-    case 'string':
-    case 'boolean':
-    case 'number':
-    case 'undefined':
-    case 'null':
-    case 'symbol':
-      return true;
-    default:
-      return false;
-  }
-}
-
 class WeakMap {
   constructor() {
     this._id = symbol();
@@ -58,7 +44,8 @@ class WeakMap {
    * @return {Any} stored value
    */
   set(obj, value) {
-    if (isPrimitiveType(obj)) {
+    var type = typeof obj;
+    if (!obj || (type !== 'object' && type !== 'function')) {
       throw new TypeError('Invalid value used as weak map key');
     }
 

--- a/tests/unit/weak-map-test.js
+++ b/tests/unit/weak-map-test.js
@@ -10,6 +10,9 @@ test('has weakMap like qualities', function(assert) {
   var a = {};
   var b = {};
   var c = {};
+  var d = function() {};
+  var e = [];
+
 
   assert.equal(map.get(a), undefined);
   assert.equal(map.get(b), undefined);
@@ -38,21 +41,41 @@ test('has weakMap like qualities', function(assert) {
   assert.equal(map2.set(a, 3), map2);
   assert.equal(map2.set(b, 4), map2);
   assert.equal(map2.set(c, 5), map2);
+  assert.equal(map2.set(d, 6), map2);
+  assert.equal(map2.set(e, 7), map2);
 
   assert.equal(map2.get(a), 3);
   assert.equal(map2.get(b), 4);
   assert.equal(map2.get(c), 5);
+  assert.equal(map2.get(d), 6);
+  assert.equal(map2.get(e), 7);
 
   assert.equal(map.get(c), 1);
   assert.equal(map.get(a), 2);
   assert.equal(map.get(b), undefined);
 });
 
-test('that error is thrown when using a non object key', function(assert) {
-  var map = new WeakMap();
+test('that error is thrown when using a primitive key', function(assert) {
+  let map = new WeakMap();
 
   assert.throws(function() {
     map.set('a', 1);
+  }, new TypeError('Invalid value used as weak map key'));
+
+  assert.throws(function() {
+    map.set(1, 1);
+  }, new TypeError('Invalid value used as weak map key'));
+
+  assert.throws(function() {
+    map.set(true, 1);
+  }, new TypeError('Invalid value used as weak map key'));
+
+  assert.throws(function() {
+    map.set(null, 1);
+  }, new TypeError('Invalid value used as weak map key'));
+
+  assert.throws(function() {
+    map.set(undefined, 1);
   }, new TypeError('Invalid value used as weak map key'));
 });
 


### PR DESCRIPTION
I brought over the tests from EmberJS's implementation and realized the assertion condition was different and the same test suite was failing.

` map.set(null, 1);` does not result in a throw