### PR TITLE
Remove support for iterables

### DIFF
--- a/addon/weak-map.js
+++ b/addon/weak-map.js
@@ -15,18 +15,22 @@ function symbol() {
 }
 
 class WeakMap {
-  constructor(iterable = []) {
-    this._id = symbol();
+  constructor() {
 
-    for (let iteration of iterable) {
-      const [key, value] = iteration;
-
-      if (typeof iteration !== 'object') {
-        throw new TypeError(`Iterator value ${key} is not an entry object`);
-      }
-
-      this.set(key, value);
+    /*
+     * NOTE: The constructor no longer takes an
+     * [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) as
+     * an argument. This is so that the implementation mimics the internal version of ember's weakmap:
+     * https://github.com/emberjs/ember.js/blob/d801dc31a406d15b545564a60ce26d4f5e6a2a32/packages/ember-metal/lib/weak_map.js#L24-L27
+     *
+     * NOTE: Another reason is that we want to support environments where ES2015 might not be avaliable and
+     * since iterables need Symbols then we decided to drop the support for them altogether.
+     */
+    if (arguments.length) {
+      throw new Error('Invoking the WeakMap constructor with arguments is not supported at this time');
     }
+
+    this._id = symbol();
   }
 
   /*
@@ -35,8 +39,8 @@ class WeakMap {
    * @return {*} stored value
    */
   get(obj) {
-    var metaInfo   = meta(obj);
-    var metaObject = metaInfo[metaKey];
+    const metaInfo = meta(obj);
+    const metaObject = metaInfo[metaKey];
 
     if (metaInfo && metaObject) {
       if (metaObject[this._id] === UNDEFINED) {
@@ -54,12 +58,13 @@ class WeakMap {
    * @return {Any} stored value
    */
   set(obj, value) {
-    var type = typeof obj;
+    const type = typeof obj;
+
     if (!obj || (type !== 'object' && type !== 'function')) {
       throw new TypeError('Invalid value used as weak map key');
     }
 
-    var metaInfo = meta(obj);
+    const metaInfo = meta(obj);
     if (value === undefined) {
       value = UNDEFINED;
     }
@@ -78,8 +83,8 @@ class WeakMap {
    * @return {Boolean} if the key exists
    */
   has(obj) {
-    var metaInfo   = meta(obj);
-    var metaObject = metaInfo[metaKey];
+    const metaInfo   = meta(obj);
+    const metaObject = metaInfo[metaKey];
 
     return (metaObject && metaObject[this._id] !== undefined);
   }
@@ -89,7 +94,7 @@ class WeakMap {
    * @param key {Object}
    */
   delete(obj) {
-    var metaInfo = meta(obj);
+    const metaInfo = meta(obj);
 
     if (this.has(obj)) {
       delete metaInfo[metaKey][this._id];

--- a/tests/unit/weak-map-test.js
+++ b/tests/unit/weak-map-test.js
@@ -90,40 +90,20 @@ test('that .has and .delete work as expected', assert => {
   assert.ok(map.has(a));
 });
 
-test('that passing an iterable to the constructor works', assert => {
-  assert.expect(5);
+test('that passing an iterable to the constructor throws an error', assert => {
+  assert.expect(1);
 
   const a = {};
   const b = {};
   const c = {};
   const d = {};
   const e = () => {};
-  const map = new WeakMap([[a, 'a'], [b, 'b'], [c, 'c', 'foo'], [d], [e]]);
 
-  assert.deepEqual(map.get(a), 'a');
-  assert.deepEqual(map.get(b), 'b');
-  assert.deepEqual(map.get(c), 'c');
-  assert.deepEqual(map.get(d), undefined);
-  assert.deepEqual(map.get(e), undefined);
+  assert.throws(() => new WeakMap([[a, 'a'], [b, 'b'], [c, 'c', 'foo'], [d], [e]]), new Error('Invoking the WeakMap constructor with arguments is not supported at this time'));
 });
 
 test('that passing a non iterable to the constructor throws correct error', assert => {
   assert.expect(2);
-  assert.throws(() => new WeakMap({}), new TypeError('iterable[Symbol.iterator] is not a function'));
-  assert.throws(() => new WeakMap(() => {}), new TypeError('iterable[Symbol.iterator] is not a function'));
-});
-
-test('that passing an iterable to the constructor with non object keys fails', assert => {
-  assert.expect(1);
-  assert.throws(() => new WeakMap('string'), new TypeError('Iterator value s is not an entry object'));
-});
-
-test('that passing an iterable to the constructor with non object keys fails', assert => {
-  assert.expect(2);
-
-  const a = {};
-  const badKey = 'bad-key';
-
-  assert.throws(() => new WeakMap([[a, 'a'], [badKey, 'foo']]), new TypeError('Invalid value used as weak map key'));
-  assert.throws(() => new WeakMap([[]]), new TypeError('Invalid value used as weak map key'));
+  assert.throws(() => new WeakMap({}), new Error('Invoking the WeakMap constructor with arguments is not supported at this time'));
+  assert.throws(() => new WeakMap(() => {}), new Error('Invoking the WeakMap constructor with arguments is not supported at this time'));
 });


### PR DESCRIPTION
Support for iterables required Symbols and since the target of this
will probably not have Symbols / many ES2015 features we decided to
drop the functionality.

Addresses: #7 