### PR TITLE
Fix Firefox 45 by moving symbol() definition before first usage.

### DIFF
--- a/vendor/ember-weakmap-polyfill.js
+++ b/vendor/ember-weakmap-polyfill.js
@@ -13,13 +13,14 @@
     var meta = _Ember.meta;
     var id = 0;
     var dateKey = new Date().getTime();
-    var metaKey = symbol();
-
-    function UNDEFINED() {} // eslint-disable-line no-inner-declarations
 
     function symbol() { // eslint-disable-line no-inner-declarations
       return '__ember' + dateKey + id++;
     }
+
+    var metaKey = symbol();
+
+    function UNDEFINED() {} // eslint-disable-line no-inner-declarations
 
     function WeakMap(iterable) { // eslint-disable-line no-inner-declarations
       this._id = symbol();


### PR DESCRIPTION
This polyfill fails to load in FF 45.9.0 on Mac OS 10.13. FF47 is ok.

The error is:

`ReferenceError: symbol is not defined`

It looks like FF is not hoisting the function definition as expected. Moving the definition of `symbol()` before its first use fixes the error.