### PR TITLE
Use native WeakMap if it is available

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -21,6 +21,15 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <script>
+      /*
+        The polyfill will not be included if window.WeakMap is detected so
+        here we just remove it so that during tests we force the polyfill to
+        be used.
+      */
+      delete window.WeakMap;
+    </script>
+
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>

--- a/tests/unit/weak-map-test.js
+++ b/tests/unit/weak-map-test.js
@@ -109,6 +109,11 @@ test('that passing an array to the constructor works', assert => {
 
 test('that passing a non iterable to the constructor throws correct error', assert => {
   assert.expect(2);
+
+  /*
+   Embers internal weakmap has this type check so we test that the polyfill does as well.
+   https://github.com/emberjs/ember.js/blob/0b190028c0fa0840175a1cd3dc2d2d9e4cadc275/packages/ember-metal/lib/weak_map.js#L40
+  */
   assert.throws(() => new Ember.WeakMap('string'), new TypeError('The weak map constructor polyfill only supports an array argument'));
   assert.throws(() => new Ember.WeakMap(() => {}), new TypeError('The weak map constructor polyfill only supports an array argument'));
 });

--- a/vendor/ember-weakmap-polyfill.js
+++ b/vendor/ember-weakmap-polyfill.js
@@ -1,7 +1,9 @@
-/* globals Ember, require*/
+/* globals Ember, require */
 
 (function() {
   var _Ember;
+  var id = 0;
+  var dateKey = new Date().getTime();
 
   if (typeof Ember !== 'undefined') {
     _Ember = Ember;
@@ -9,41 +11,38 @@
     _Ember = require('ember').default;
   }
 
+  function symbol() {
+    return '__ember' + dateKey + id++;
+  }
+
+  function UNDEFINED() {}
+  
+  function FakeWeakMap(iterable) {
+    this._id = symbol();
+
+    if (iterable === null || iterable === undefined) {
+      return;
+    } else if (Array.isArray(iterable)) {
+      for (var i = 0; i < iterable.length; i++) {
+        var key = iterable[i][0];
+        var value = iterable[i][1];
+        this.set(key, value);
+      }
+    } else {
+      throw new TypeError('The weak map constructor polyfill only supports an array argument');
+    }
+  }
+  
   if (!_Ember.WeakMap) {
     var meta = _Ember.meta;
-    var id = 0;
-    var dateKey = new Date().getTime();
-
-    function symbol() { // eslint-disable-line no-inner-declarations
-      return '__ember' + dateKey + id++;
-    }
-
     var metaKey = symbol();
-
-    function UNDEFINED() {} // eslint-disable-line no-inner-declarations
-
-    function WeakMap(iterable) { // eslint-disable-line no-inner-declarations
-      this._id = symbol();
-
-      if (iterable === null || iterable === undefined) {
-        return;
-      } else if (Array.isArray(iterable)) {
-        for (var i = 0; i < iterable.length; i++) {
-          var key = iterable[i][0];
-          var value = iterable[i][1];
-          this.set(key, value);
-        }
-      } else {
-        throw new TypeError('The weak map constructor polyfill only supports an array argument');
-      }
-    }
 
     /*
      * @method get
      * @param key {Object}
      * @return {*} stored value
      */
-    WeakMap.prototype.get = function(obj) {
+    FakeWeakMap.prototype.get = function(obj) {
       var metaInfo = meta(obj);
       var metaObject = metaInfo[metaKey];
 
@@ -62,7 +61,7 @@
      * @param value {Any}
      * @return {Any} stored value
      */
-    WeakMap.prototype.set = function(obj, value) {
+    FakeWeakMap.prototype.set = function(obj, value) {
       var type = typeof obj;
 
       if (!obj || (type !== 'object' && type !== 'function')) {
@@ -87,7 +86,7 @@
      * @param key {Object}
      * @return {Boolean} if the key exists
      */
-    WeakMap.prototype.has = function(obj) {
+    FakeWeakMap.prototype.has = function(obj) {
       var metaInfo   = meta(obj);
       var metaObject = metaInfo[metaKey];
 
@@ -98,7 +97,7 @@
      * @method delete
      * @param key {Object}
      */
-    WeakMap.prototype.delete = function(obj) {
+    FakeWeakMap.prototype.delete = function(obj) {
       var metaInfo = meta(obj);
 
       if (this.has(obj)) {
@@ -110,6 +109,10 @@
       return false;
     }
 
-    _Ember.WeakMap = WeakMap;
+    if (typeof WeakMap === 'function') {
+      _Ember.WeakMap = WeakMap;
+    } else {
+      _Ember.WeakMap = FakeWeakMap;
+    }
   }
 })();


### PR DESCRIPTION
- Use native WeakMap if it is available
- Restructure polyfill logic such "that the only constructs allowed within a Block are Statement construct." This prevents a firefox issue with hoisting. (Fixes #21)